### PR TITLE
Do not include empty root level owners

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: "1.72.0"
+          toolchain: stable
       - uses: actions-rs/cargo@v1
         with:
           command: build
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: "1.72.0"
+          toolchain: stable
       - uses: actions-rs/cargo@v1
         with:
           command: test

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: "1.72.0"
       - uses: actions-rs/cargo@v1
         with:
           command: build
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: "1.72.0"
       - uses: actions-rs/cargo@v1
         with:
           command: test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,7 +175,7 @@ checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
 
 [[package]]
 name = "github-distributed-owners"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,6 @@
 name = "github-distributed-owners"
 version = "0.1.1"
 edition = "2021"
-rust-version = "1.72.0"
 authors = ["Andrew Ring"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "github-distributed-owners"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
+rust-version = "1.72.0"
 authors = ["Andrew Ring"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/codeowners.rs
+++ b/src/codeowners.rs
@@ -15,6 +15,8 @@ pub fn to_codeowners_string(codeowners: HashMap<String, HashSet<String>>) -> Str
             }
             line
         })
+        // Don't include a root level owner line if no owners are specified
+        .filter(|line| line != "/")
         .join("\n")
 }
 

--- a/src/owners_file.rs
+++ b/src/owners_file.rs
@@ -39,8 +39,10 @@ impl OwnersFileConfig {
             }
             if line.contains(char::is_whitespace) {
                 return Err(anyhow!(
-                    "Invalid user/group '{}', cannot contain whitespace",
-                    line
+                    "Invalid user/group '{}' cannot contain whitespace. Found at {}:{}",
+                    line,
+                    file!(),
+                    line!()
                 ));
             }
             current_set.owners.insert(line.to_string());

--- a/src/owners_set.rs
+++ b/src/owners_set.rs
@@ -26,28 +26,37 @@ impl OwnersSet {
             let variable = &captures["variable"];
             let value = &captures["value"];
             match variable {
-                "inherit" => match value {
-                    "true" => {
-                        self.inherit = Some(true);
-                    }
-                    "false" => {
-                        self.inherit = Some(false);
-                    }
-                    _ => {
-                        return Err(anyhow!(
-                            "Invalid value for inherit '{}'. Must be 'true' or 'false'.",
-                            value
+                "inherit" => {
+                    match value {
+                        "true" => {
+                            self.inherit = Some(true);
+                        }
+                        "false" => {
+                            self.inherit = Some(false);
+                        }
+                        _ => {
+                            return Err(anyhow!(
+                            "Invalid value for inherit '{}': Must be 'true' or 'false'.  Found at {}:{}",
+                            value, file!(), line!()
                         ))
+                        }
                     }
-                },
+                }
                 _ => {
-                    return Err(anyhow!("Invalid set variable '{}'", variable));
+                    return Err(anyhow!(
+                        "Invalid set variable '{}' in {}:{}",
+                        variable,
+                        file!(),
+                        line!()
+                    ));
                 }
             }
         } else {
             return Err(anyhow!(
-                "Invalid set format in '{}'. Expected 'set <variable> = <value>'",
-                line
+                "Invalid set format '{}']. Expected 'set <variable> = <value>'. Found at {}:{}",
+                line,
+                file!(),
+                line!(),
             ));
         }
         Ok(true)

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -61,6 +61,8 @@ mod test {
             indoc! {
                 "ada.lovelace
                 grace.hopper
+                [*.rs]
+                foo.bar
                 "
             },
         )?;
@@ -72,6 +74,7 @@ mod test {
             ################################################################################
 
             / ada.lovelace grace.hopper
+            /*.rs ada.lovelace foo.bar grace.hopper
 
             ################################################################################
             #                             AUTO GENERATED FILE
@@ -180,6 +183,64 @@ mod test {
 
             / ada.lovelace grace.hopper
             /subdir/foo/ ada.lovelace grace.hopper katherine.johnson margaret.hamilton
+            /subdir/foo/*.rs grace.hopper
+
+            ################################################################################
+            #                             AUTO GENERATED FILE
+            #                            Do Not Manually Update
+            ################################################################################
+            "
+        };
+
+        let output_file = root_dir.join("CODEOWNERS");
+        let repo_root = Some(root_dir.to_path_buf());
+        let implicit_inherit = true;
+
+        generate_codeowners_from_files(repo_root, Some(output_file.clone()), implicit_inherit)?;
+
+        let generated_codeowners = fs::read_to_string(output_file)?;
+
+        assert_eq!(generated_codeowners, expected);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_empty_root_blanket_owners() -> anyhow::Result<()> {
+        let temp_dir = tempdir()?;
+        let root_dir = temp_dir.path();
+        create_test_file(
+            &temp_dir,
+            "OWNERS",
+            indoc! {
+                "[*.rs]
+                ada.lovelace
+                grace.hopper
+                "
+            },
+        )?;
+        create_test_file(
+            &temp_dir,
+            "subdir/foo/OWNERS",
+            indoc! {"\
+                katherine.johnson
+                margaret.hamilton
+
+                [*.rs]
+                set inherit = false
+                grace.hopper
+                "
+            },
+        )?;
+
+        let expected = indoc! {"\
+            ################################################################################
+            #                             AUTO GENERATED FILE
+            #                            Do Not Manually Update
+            ################################################################################
+
+            /*.rs ada.lovelace grace.hopper
+            /subdir/foo/ katherine.johnson margaret.hamilton
             /subdir/foo/*.rs grace.hopper
 
             ################################################################################


### PR DESCRIPTION
Additionally adds more details to errors, for easier tracing.

Closes #9 