### PR TITLE
Handle the root dir as a special case to match CODEOWNERS requirements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,7 +175,7 @@ checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
 
 [[package]]
 name = "github-distributed-owners"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "github-distributed-owners"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 authors = ["Andrew Ring"]
 

--- a/src/codeowners.rs
+++ b/src/codeowners.rs
@@ -9,6 +9,12 @@ pub fn to_codeowners_string(codeowners: HashMap<String, HashSet<String>>) -> Str
         .sorted()
         .map(|pattern| {
             let mut line = pattern.to_string();
+            if line == "/" {
+                // Unlike non-root directories, the repo root directory cannot be used as a catch all path.
+                // Instead, you have to use `*` at the root directory to achieve the same results.
+                // https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+                line = "*".to_string();
+            }
             let owners = codeowners.get(pattern).unwrap().iter().sorted().join(" ");
             if !owners.is_empty() {
                 line = format!("{} {}", line, owners);
@@ -16,7 +22,7 @@ pub fn to_codeowners_string(codeowners: HashMap<String, HashSet<String>>) -> Str
             line
         })
         // Don't include a root level owner line if no owners are specified
-        .filter(|line| line != "/")
+        .filter(|line| line != "*")
         .join("\n")
 }
 
@@ -672,7 +678,7 @@ mod test {
         ]);
 
         let expected = indoc!(
-            "/ ada.lovelace
+            "* ada.lovelace
             /*.rs ada.lovelace margaret.hamilton
             /foo/bar/ ada.lovelace grace.hopper
             /foo/bar/*.rs katherine.johnson"
@@ -720,7 +726,7 @@ mod test {
         ]);
 
         let expected = indoc!(
-            "/ ada.lovelace
+            "* ada.lovelace
             /*.rs ada.lovelace margaret.hamilton
             /foo/bar/ ada.lovelace grace.hopper
             /foo/bar/*.rs katherine.johnson"
@@ -762,7 +768,7 @@ mod test {
         ]);
 
         let expected = indoc!(
-            "/ ada.lovelace
+            "* ada.lovelace
             /*.rs ada.lovelace margaret.hamilton
             /foo/bar/
             /foo/bar/*.rs katherine.johnson"

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -77,7 +77,7 @@ mod test {
             #        https://github.com/andrewring/github-distributed-owners#readme
             ################################################################################
 
-            / ada.lovelace grace.hopper
+            * ada.lovelace grace.hopper
             /*.rs ada.lovelace foo.bar grace.hopper
 
             ################################################################################
@@ -133,7 +133,7 @@ mod test {
             #        https://github.com/andrewring/github-distributed-owners#readme
             ################################################################################
 
-            / ada.lovelace grace.hopper
+            * ada.lovelace grace.hopper
             /subdir/foo/ ada.lovelace grace.hopper katherine.johnson margaret.hamilton
 
             ################################################################################
@@ -193,7 +193,7 @@ mod test {
             #        https://github.com/andrewring/github-distributed-owners#readme
             ################################################################################
 
-            / ada.lovelace grace.hopper
+            * ada.lovelace grace.hopper
             /subdir/foo/ ada.lovelace grace.hopper katherine.johnson margaret.hamilton
             /subdir/foo/*.rs grace.hopper
 


### PR DESCRIPTION
Unlike non-root directories, the repo root directory cannot be used as a catch all path.
Instead, you have to use `*` at the root directory to achieve the same results.
https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners