### PR TITLE
Add filter to only process OWNERS files controlled by git

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,7 +173,7 @@ checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
 
 [[package]]
 name = "github-distributed-owners"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,6 +103,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap-verbosity-flag"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1eef05769009513df2eb1c3b4613e7fad873a14c600ff025b08f250f59fee7de"
+dependencies = [
+ "clap",
+ "log",
+]
+
+[[package]]
 name = "clap_builder"
 version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -145,6 +155,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
+name = "env_logger"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
+dependencies = [
+ "humantime",
+ "is-terminal",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -177,9 +200,12 @@ version = "0.1.6"
 dependencies = [
  "anyhow",
  "clap",
+ "clap-verbosity-flag",
+ "env_logger",
  "indoc",
  "itertools",
  "lazy_static",
+ "log",
  "regex",
  "tempfile",
 ]
@@ -191,10 +217,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
 name = "indoc"
 version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c785eefb63ebd0e33416dfcb8d6da0bf27ce752843a45632a67bf10d4d4b5c4"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
+dependencies = [
+ "hermit-abi",
+ "rustix",
+ "windows-sys",
+]
 
 [[package]]
 name = "itertools"
@@ -222,6 +271,12 @@ name = "linux-raw-sys"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
+
+[[package]]
+name = "log"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "memchr"
@@ -329,6 +384,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -339,6 +403,37 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,12 @@ categories = ["command-line-utilities", "development-tools"]
 [dependencies]
 anyhow = "1.0.75"
 clap = { version = "4.4.2", features = ["derive"] }
+clap-verbosity-flag = "2.0.1"
+env_logger = "0.10.0"
 indoc = "2.0.3"
 itertools = "0.11.0"
 lazy_static = "1.4.0"
+log = "0.4.20"
 regex = "1.9.5"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "github-distributed-owners"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 authors = ["Andrew Ring"]
 

--- a/src/allow_filter.rs
+++ b/src/allow_filter.rs
@@ -1,0 +1,51 @@
+use anyhow::anyhow;
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+pub trait AllowFilter {
+    fn allowed(&self, path: &Path) -> bool;
+}
+
+pub struct FilterGitMetadata {}
+
+impl AllowFilter for FilterGitMetadata {
+    fn allowed(&self, path: &Path) -> bool {
+        for component in path {
+            if component == ".git" {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+pub struct AllowList {
+    allowed_files: HashSet<PathBuf>,
+}
+
+impl AllowFilter for AllowList {
+    fn allowed(&self, path: &Path) -> bool {
+        self.allowed_files.contains(path)
+    }
+}
+
+impl AllowList {
+    pub fn allow_git_files() -> anyhow::Result<AllowList> {
+        let output = Command::new("git").arg("ls-files").output()?;
+        if !output.status.success() {
+            return Err(anyhow!(
+                "Error gathering git files:\n{}",
+                String::from_utf8_lossy(&output.stderr)
+            ));
+        }
+        let git_files = String::from_utf8_lossy(&output.stdout)
+            .lines()
+            .map(PathBuf::from)
+            .collect();
+        let allow_list = AllowList {
+            allowed_files: git_files,
+        };
+        Ok(allow_list)
+    }
+}

--- a/src/allow_filter.rs
+++ b/src/allow_filter.rs
@@ -1,4 +1,6 @@
 use anyhow::anyhow;
+use itertools::Itertools;
+use log::trace;
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -7,6 +9,7 @@ pub trait AllowFilter {
     fn allowed(&self, path: &Path) -> bool;
 }
 
+#[derive(Debug)]
 pub struct FilterGitMetadata {}
 
 impl AllowFilter for FilterGitMetadata {
@@ -39,13 +42,61 @@ impl AllowList {
                 String::from_utf8_lossy(&output.stderr)
             ));
         }
-        let git_files = String::from_utf8_lossy(&output.stdout)
+        let git_files: HashSet<PathBuf> = String::from_utf8_lossy(&output.stdout)
             .lines()
             .map(PathBuf::from)
+            // When walking the file tree, paths are absolute.
+            // Canonicalize is needed to make these paths to match.
+            .map(|p| {
+                p.canonicalize()
+                    .expect("Error resolving file path from git ls-files")
+            })
             .collect();
+        trace!(
+            "Git files:{}",
+            git_files
+                .iter()
+                .sorted()
+                .map(|p| format!("\n - {:?}", &p))
+                .join("")
+        );
         let allow_list = AllowList {
             allowed_files: git_files,
         };
         Ok(allow_list)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::allow_filter::{AllowFilter, AllowList, FilterGitMetadata};
+    use std::collections::HashSet;
+    use std::path::{Path, PathBuf};
+
+    #[test]
+    fn filter_git_metadata() {
+        let filter = FilterGitMetadata {};
+        assert!(filter.allowed(Path::new("Cargo.lock")));
+        assert!(filter.allowed(Path::new("LICENSE")));
+        assert!(filter.allowed(Path::new("OWNERS")));
+        assert!(filter.allowed(Path::new("src/main.rs")));
+
+        assert!(!filter.allowed(Path::new(".git/hooks/pre-commit")));
+    }
+
+    #[test]
+    fn allow_list() {
+        let allowed_files = ["Cargo.lock", "LICENSE", "OWNERS"]
+            .iter()
+            .map(PathBuf::from)
+            .collect::<HashSet<PathBuf>>();
+        let filter = AllowList { allowed_files };
+        assert!(filter.allowed(Path::new("Cargo.lock")));
+        assert!(filter.allowed(Path::new("LICENSE")));
+        assert!(filter.allowed(Path::new("OWNERS")));
+
+        assert!(!filter.allowed(Path::new(".git/hooks/pre-commit")));
+        assert!(!filter.allowed(Path::new("src/main.rs")));
+        assert!(!filter.allowed(Path::new("src/OWNERS")));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use crate::allow_filter::{AllowFilter, AllowList, FilterGitMetadata};
 use clap::Parser;
 use std::path::PathBuf;
 
@@ -7,6 +8,7 @@ mod owners_set;
 mod owners_tree;
 mod pipeline;
 
+mod allow_filter;
 #[cfg(test)]
 mod test_utils;
 
@@ -27,15 +29,30 @@ struct Args {
     #[arg(short, long, default_value = "true")]
     // NB: Option<bool> allows for --implicit-inherit [true|false], default means it's always Some
     implicit_inherit: Option<bool>,
+
+    /// Don't filter out files which are not managed by git.
+    #[arg(long)]
+    allow_non_git_files: bool,
 }
 
-fn main() -> anyhow::Result<()> {
-    let args = Args::parse();
-
+fn run_pipeline<F: AllowFilter>(args: Args, allow_filter: &F) -> anyhow::Result<()> {
     pipeline::generate_codeowners_from_files(
         args.repo_root,
         args.output_file,
         args.implicit_inherit
             .expect("--implicit-inherit must be set to either true or false"),
+        allow_filter,
     )
+}
+
+fn main() -> anyhow::Result<()> {
+    let args = Args::parse();
+
+    if args.allow_non_git_files {
+        let allow_filter = FilterGitMetadata {};
+        run_pipeline(args, &allow_filter)
+    } else {
+        let allow_filter = AllowList::allow_git_files()?;
+        run_pipeline(args, &allow_filter)
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use crate::allow_filter::{AllowFilter, AllowList, FilterGitMetadata};
 use clap::Parser;
+use clap_verbosity_flag::Verbosity;
 use std::path::PathBuf;
 
 mod codeowners;
@@ -33,6 +34,9 @@ struct Args {
     /// Don't filter out files which are not managed by git.
     #[arg(long)]
     allow_non_git_files: bool,
+
+    #[command(flatten)]
+    verbose: Verbosity,
 }
 
 fn run_pipeline<F: AllowFilter>(args: Args, allow_filter: &F) -> anyhow::Result<()> {
@@ -47,6 +51,9 @@ fn run_pipeline<F: AllowFilter>(args: Args, allow_filter: &F) -> anyhow::Result<
 
 fn main() -> anyhow::Result<()> {
     let args = Args::parse();
+    env_logger::Builder::new()
+        .filter_level(args.verbose.log_level_filter())
+        .init();
 
     if args.allow_non_git_files {
         let allow_filter = FilterGitMetadata {};

--- a/src/owners_tree.rs
+++ b/src/owners_tree.rs
@@ -1,5 +1,6 @@
 use crate::allow_filter::AllowFilter;
 use crate::owners_file::OwnersFileConfig;
+use log::{debug, trace};
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -25,10 +26,19 @@ impl TreeNode {
         F: AllowFilter,
     {
         let owners_file = self.path.join("OWNERS");
-        if !owners_file.exists() || !owners_file.is_file() || !allow_filter.allowed(&owners_file) {
+        if !owners_file.exists() || !owners_file.is_file() {
+            return Ok(false);
+        }
+        if !allow_filter.allowed(&owners_file) {
+            trace!(
+                "Skipping {:?} in {:?} due to filter",
+                owners_file,
+                self.path
+            );
             return Ok(false);
         }
 
+        debug!("Parsing {:?}", &owners_file);
         let owners_config = OwnersFileConfig::from_file(owners_file)?;
         self.owners_config = owners_config;
 

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1,3 +1,4 @@
+use crate::allow_filter::AllowFilter;
 use crate::codeowners::{generate_codeowners, to_codeowners_string};
 use crate::owners_tree::OwnersTree;
 use indoc::indoc;
@@ -14,13 +15,17 @@ const AUTO_GENERATED_NOTICE: &str = indoc! {"\
     ################################################################################"
 };
 
-pub fn generate_codeowners_from_files(
+pub fn generate_codeowners_from_files<F>(
     repo_root: Option<PathBuf>,
     output_file: Option<PathBuf>,
     implicit_inherit: bool,
-) -> anyhow::Result<()> {
+    allow_filter: &F,
+) -> anyhow::Result<()>
+where
+    F: AllowFilter,
+{
     let root = repo_root.unwrap_or(std::env::current_dir()?);
-    let tree = OwnersTree::load_from_files(root)?;
+    let tree = OwnersTree::load_from_files(root, allow_filter)?;
 
     let codeowners = generate_codeowners(&tree, implicit_inherit)?;
     let mut codeowners_text = to_codeowners_string(codeowners);
@@ -47,11 +52,14 @@ pub fn generate_codeowners_from_files(
 
 #[cfg(test)]
 mod test {
+    use crate::allow_filter::FilterGitMetadata;
     use crate::pipeline::generate_codeowners_from_files;
     use crate::test_utils::create_test_file;
     use indoc::indoc;
     use std::fs;
     use tempfile::tempdir;
+
+    const ALLOW_ANY: FilterGitMetadata = FilterGitMetadata {};
 
     #[test]
     fn test_simple() -> anyhow::Result<()> {
@@ -93,7 +101,12 @@ mod test {
         let repo_root = Some(root_dir.to_path_buf());
         let implicit_inherit = true;
 
-        generate_codeowners_from_files(repo_root, Some(output_file.clone()), implicit_inherit)?;
+        generate_codeowners_from_files(
+            repo_root,
+            Some(output_file.clone()),
+            implicit_inherit,
+            &ALLOW_ANY,
+        )?;
 
         let generated_codeowners = fs::read_to_string(output_file)?;
 
@@ -149,7 +162,12 @@ mod test {
         let repo_root = Some(root_dir.to_path_buf());
         let implicit_inherit = true;
 
-        generate_codeowners_from_files(repo_root, Some(output_file.clone()), implicit_inherit)?;
+        generate_codeowners_from_files(
+            repo_root,
+            Some(output_file.clone()),
+            implicit_inherit,
+            &ALLOW_ANY,
+        )?;
 
         let generated_codeowners = fs::read_to_string(output_file)?;
 
@@ -210,7 +228,12 @@ mod test {
         let repo_root = Some(root_dir.to_path_buf());
         let implicit_inherit = true;
 
-        generate_codeowners_from_files(repo_root, Some(output_file.clone()), implicit_inherit)?;
+        generate_codeowners_from_files(
+            repo_root,
+            Some(output_file.clone()),
+            implicit_inherit,
+            &ALLOW_ANY,
+        )?;
 
         let generated_codeowners = fs::read_to_string(output_file)?;
 
@@ -272,7 +295,12 @@ mod test {
         let repo_root = Some(root_dir.to_path_buf());
         let implicit_inherit = true;
 
-        generate_codeowners_from_files(repo_root, Some(output_file.clone()), implicit_inherit)?;
+        generate_codeowners_from_files(
+            repo_root,
+            Some(output_file.clone()),
+            implicit_inherit,
+            &ALLOW_ANY,
+        )?;
 
         let generated_codeowners = fs::read_to_string(output_file)?;
 


### PR DESCRIPTION
Prior to this, temp files, such as those under `target/` would be processed, and could erroneously impact the output.

Fixes #27 