### PR TITLE
feat: allow "insert" of special strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ repos:
     hooks:
       - id: github-distributed-owners
 ```
+
 > [!WARNING]
 > pre-commit does not trigger on deletion of files matching patterns,
 > so removal of an OWNERS file can be missed by pre-commit.
@@ -208,6 +209,35 @@ include /python/OWNERS
 
 Currently, `include`d OWNERS files may not `set inherit = ...`. This is to avoid the challenge
 of defining semantics around how multiple conflicting `set inherit = ...` should interact.
+
+## Inserting Arbitrary Text
+
+You can insert arbitrary lines of text into the generated CODEOWNERS file using the `insert` directive.
+Each `insert` line produces a single line in the output, placed before the generated ownership entries.
+This is useful for adding comments, [CODEOWNERS sections](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file),
+or any other raw CODEOWNERS syntax that cannot be expressed through the standard OWNERS directives.
+
+Example:
+
+```shell
+# /OWNERS
+insert # This repository is maintained by the platform team
+insert ^[DevOps] @org/devops-team
+user0
+user1
+```
+
+This produces the following in the generated CODEOWNERS (between the auto-generated header and the ownership rules):
+
+```
+# This repository is maintained by the platform team
+^[DevOps] @org/devops-team
+
+* @user0 @user1
+```
+
+Insertions from OWNERS files across the tree are collected and placed together, in tree traversal order,
+before all generated ownership entries.
 
 ## License
 

--- a/src/codeowners.rs
+++ b/src/codeowners.rs
@@ -3,7 +3,9 @@ use itertools::Itertools;
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
-pub fn to_codeowners_string(codeowners: HashMap<String, HashSet<String>>) -> String {
+pub type CodeownersMap = HashMap<String, HashSet<String>>;
+
+pub fn to_codeowners_string(codeowners: CodeownersMap) -> String {
     codeowners
         .keys()
         .sorted()
@@ -47,16 +49,18 @@ pub fn to_codeowners_string(codeowners: HashMap<String, HashSet<String>>) -> Str
 pub fn generate_codeowners(
     owners_tree: &OwnersTree,
     implicit_inherit: bool,
-) -> anyhow::Result<HashMap<String, HashSet<String>>> {
+) -> anyhow::Result<(CodeownersMap, Vec<String>)> {
     let mut codeowners = HashMap::new();
+    let mut insertions = Vec::new();
     add_codeowners(
         owners_tree,
         &owners_tree.path,
         &HashSet::default(),
         implicit_inherit,
         &mut codeowners,
+        &mut insertions,
     )?;
-    Ok(codeowners)
+    Ok((codeowners, insertions))
 }
 
 fn add_codeowners(
@@ -64,7 +68,8 @@ fn add_codeowners(
     root_path: &Path,
     parent_owners: &HashSet<String>,
     implicit_inherit: bool,
-    codeowners: &mut HashMap<String, HashSet<String>>,
+    codeowners: &mut CodeownersMap,
+    insertions: &mut Vec<String>,
 ) -> anyhow::Result<()> {
     let owners_config = &tree_node.owners_config;
     let owners_set = &owners_config.all_files;
@@ -86,6 +91,8 @@ fn add_codeowners(
     }
     owners.extend(owners_set.owners.clone());
 
+    insertions.extend(owners_config.insertions.clone());
+
     // Add directory level ownership
     codeowners.insert(relative_path.clone(), owners.clone());
 
@@ -103,7 +110,14 @@ fn add_codeowners(
     }
 
     for child in &tree_node.children {
-        add_codeowners(child, root_path, &owners, implicit_inherit, codeowners)?;
+        add_codeowners(
+            child,
+            root_path,
+            &owners,
+            implicit_inherit,
+            codeowners,
+            insertions,
+        )?;
     }
 
     Ok(())
@@ -132,7 +146,7 @@ mod test {
                         .map(|s| s.to_string())
                         .collect::<HashSet<String>>(),
                 },
-                pattern_overrides: HashMap::default(),
+                ..OwnersFileConfig::default()
             },
             children: Vec::default(),
         };
@@ -146,7 +160,7 @@ mod test {
                 .collect::<HashSet<String>>(),
         )]);
 
-        let codeowners = generate_codeowners(&tree_node, implicit_inherit)?;
+        let (codeowners, _) = generate_codeowners(&tree_node, implicit_inherit)?;
 
         assert_eq!(codeowners, expected);
 
@@ -166,7 +180,7 @@ mod test {
                         .map(|s| s.to_string())
                         .collect::<HashSet<String>>(),
                 },
-                pattern_overrides: HashMap::default(),
+                ..OwnersFileConfig::default()
             },
             children: vec![TreeNode {
                 path: PathBuf::from("/tree/root/foo/bar"),
@@ -179,7 +193,7 @@ mod test {
                             .map(|s| s.to_string())
                             .collect::<HashSet<String>>(),
                     },
-                    pattern_overrides: HashMap::default(),
+                    ..OwnersFileConfig::default()
                 },
                 children: vec![],
             }],
@@ -208,7 +222,7 @@ mod test {
             ),
         ]);
 
-        let codeowners = generate_codeowners(&tree_node, implicit_inherit)?;
+        let (codeowners, _) = generate_codeowners(&tree_node, implicit_inherit)?;
 
         assert_eq!(codeowners, expected);
 
@@ -238,6 +252,7 @@ mod test {
                         ..OwnersSet::default()
                     },
                 )]),
+                insertions: Vec::default(),
             },
             children: Vec::default(),
         };
@@ -265,7 +280,7 @@ mod test {
             ),
         ]);
 
-        let codeowners = generate_codeowners(&tree_node, implicit_inherit)?;
+        let (codeowners, _) = generate_codeowners(&tree_node, implicit_inherit)?;
 
         assert_eq!(codeowners, expected);
 
@@ -295,6 +310,7 @@ mod test {
                         ..OwnersSet::default()
                     },
                 )]),
+                insertions: Vec::default(),
             },
             children: vec![TreeNode {
                 path: PathBuf::from("/tree/root/foo/bar"),
@@ -317,6 +333,7 @@ mod test {
                             ..OwnersSet::default()
                         },
                     )]),
+                    insertions: Vec::default(),
                 },
                 children: vec![],
             }],
@@ -354,7 +371,7 @@ mod test {
             ),
         ]);
 
-        let codeowners = generate_codeowners(&tree_node, implicit_inherit)?;
+        let (codeowners, _) = generate_codeowners(&tree_node, implicit_inherit)?;
 
         assert_eq!(codeowners, expected);
 
@@ -384,6 +401,7 @@ mod test {
                         ..OwnersSet::default()
                     },
                 )]),
+                insertions: Vec::default(),
             },
             children: vec![TreeNode {
                 path: PathBuf::from("/tree/root/foo/bar"),
@@ -406,6 +424,7 @@ mod test {
                             ..OwnersSet::default()
                         },
                     )]),
+                    insertions: Vec::default(),
                 },
                 children: vec![],
             }],
@@ -443,7 +462,7 @@ mod test {
             ),
         ]);
 
-        let codeowners = generate_codeowners(&tree_node, implicit_inherit)?;
+        let (codeowners, _) = generate_codeowners(&tree_node, implicit_inherit)?;
 
         assert_eq!(codeowners, expected);
 
@@ -473,6 +492,7 @@ mod test {
                         inherit: Some(false),
                     },
                 )]),
+                insertions: Vec::default(),
             },
             children: vec![TreeNode {
                 path: PathBuf::from("/tree/root/foo/bar"),
@@ -495,6 +515,7 @@ mod test {
                             ..OwnersSet::default()
                         },
                     )]),
+                    insertions: Vec::default(),
                 },
                 children: vec![],
             }],
@@ -532,7 +553,7 @@ mod test {
             ),
         ]);
 
-        let codeowners = generate_codeowners(&tree_node, implicit_inherit)?;
+        let (codeowners, _) = generate_codeowners(&tree_node, implicit_inherit)?;
 
         assert_eq!(codeowners, expected);
 
@@ -562,6 +583,7 @@ mod test {
                         inherit: Some(true),
                     },
                 )]),
+                insertions: Vec::default(),
             },
             children: vec![TreeNode {
                 path: PathBuf::from("/tree/root/foo/bar"),
@@ -584,6 +606,7 @@ mod test {
                             ..OwnersSet::default()
                         },
                     )]),
+                    insertions: Vec::default(),
                 },
                 children: vec![],
             }],
@@ -621,7 +644,7 @@ mod test {
             ),
         ]);
 
-        let codeowners = generate_codeowners(&tree_node, implicit_inherit)?;
+        let (codeowners, _) = generate_codeowners(&tree_node, implicit_inherit)?;
 
         assert_eq!(codeowners, expected);
 
@@ -641,7 +664,7 @@ mod test {
                         .map(|s| s.to_string())
                         .collect::<HashSet<String>>(),
                 },
-                pattern_overrides: HashMap::default(),
+                ..OwnersFileConfig::default()
             },
             children: vec![TreeNode {
                 path: PathBuf::from("/tree/root/foo/bar"),
@@ -651,7 +674,7 @@ mod test {
                         inherit: Some(false),
                         owners: HashSet::default(),
                     },
-                    pattern_overrides: HashMap::default(),
+                    ..OwnersFileConfig::default()
                 },
                 children: vec![],
             }],
@@ -669,7 +692,7 @@ mod test {
             ("/foo/bar/".to_string(), HashSet::default()),
         ]);
 
-        let codeowners = generate_codeowners(&tree_node, implicit_inherit)?;
+        let (codeowners, _) = generate_codeowners(&tree_node, implicit_inherit)?;
 
         assert_eq!(codeowners, expected);
 

--- a/src/owners_file.rs
+++ b/src/owners_file.rs
@@ -11,6 +11,7 @@ use std::path::PathBuf;
 pub struct OwnersFileConfig {
     pub all_files: OwnersSet,
     pub pattern_overrides: HashMap<String, OwnersSet>,
+    pub insertions: Vec<String>,
 }
 
 impl OwnersFileConfig {
@@ -60,11 +61,24 @@ impl OwnersFileConfig {
         }
 
         for (i, raw_line) in text.lines().enumerate() {
+            let line_number = i + 1;
+
+            if let Some(text) = maybe_get_insert(raw_line.trim()) {
+                if active_pattern_key.is_some() {
+                    return Err(anyhow!(
+                        "insert is not allowed in path-specific sections. Found at {}:{}",
+                        source,
+                        line_number
+                    ));
+                }
+                config.insertions.push(text);
+                continue;
+            }
+
             let line = clean_line(raw_line);
             if line.is_empty() {
                 continue;
             }
-            let line_number = i + 1;
 
             if let Some(include_file) = maybe_get_include(line)
                 .map_err(|error| anyhow!("{} Found at {}:{}", error, source, line_number))?
@@ -169,6 +183,11 @@ fn maybe_get_file_pattern(line: &str) -> Option<String> {
     }
 }
 
+/// Parses an insert directive, e.g., `insert THIS IS THE TEXT I WANT INSERTED`.
+fn maybe_get_insert(line: &str) -> Option<String> {
+    line.strip_prefix("insert ").map(|text| text.to_string())
+}
+
 /// Parses an include directive, e.g., `include path/to/another/OWNERS`.
 fn maybe_get_include(line: &str) -> anyhow::Result<Option<String>> {
     lazy_static! {
@@ -269,7 +288,9 @@ fn check_no_circular_include(
 
 #[cfg(test)]
 mod tests {
-    use crate::owners_file::{maybe_get_file_pattern, maybe_get_include, OwnersFileConfig};
+    use crate::owners_file::{
+        maybe_get_file_pattern, maybe_get_include, maybe_get_insert, OwnersFileConfig,
+    };
     use crate::owners_set::OwnersSet;
     use indoc::indoc;
     use std::collections::{HashMap, HashSet};
@@ -290,7 +311,7 @@ mod tests {
                     .map(|s| s.to_string())
                     .collect::<HashSet<String>>(),
             },
-            pattern_overrides: HashMap::default(),
+            ..OwnersFileConfig::default()
         };
 
         let parsed = OwnersFileConfig::from_text(input, "test data", "test data")?;
@@ -315,7 +336,7 @@ mod tests {
                     .map(|s| s.to_string())
                     .collect::<HashSet<String>>(),
             },
-            pattern_overrides: HashMap::default(),
+            ..OwnersFileConfig::default()
         };
 
         let parsed = OwnersFileConfig::from_text(input, "test data", "test data")?;
@@ -352,6 +373,7 @@ mod tests {
                         .collect::<HashSet<String>>(),
                 },
             )]),
+            insertions: Vec::default(),
         };
 
         let parsed = OwnersFileConfig::from_text(input, "test data", "test data")?;
@@ -387,5 +409,82 @@ mod tests {
         assert!(maybe_get_include("include path with spaces").is_err()); // Regex `\S+` handles this.
         assert_eq!(maybe_get_include("not an include")?, None);
         Ok(())
+    }
+
+    #[test]
+    fn test_maybe_get_insert() {
+        assert_eq!(
+            maybe_get_insert("insert THIS IS THE TEXT"),
+            Some("THIS IS THE TEXT".to_string())
+        );
+        assert_eq!(
+            maybe_get_insert("insert # comment-like text"),
+            Some("# comment-like text".to_string())
+        );
+        assert_eq!(maybe_get_insert("insert"), None);
+        assert_eq!(maybe_get_insert("ada.lovelace"), None);
+        assert_eq!(maybe_get_insert(""), None);
+    }
+
+    #[test]
+    fn parse_with_insert() -> anyhow::Result<()> {
+        let input = indoc! {"\
+            ada.lovelace
+            grace.hopper
+            insert THIS IS THE TEXT I WANT INSERTED
+            "
+        };
+        let expected = OwnersFileConfig {
+            all_files: OwnersSet {
+                inherit: None,
+                owners: vec!["ada.lovelace", "grace.hopper"]
+                    .into_iter()
+                    .map(|s| s.to_string())
+                    .collect::<HashSet<String>>(),
+            },
+            insertions: vec!["THIS IS THE TEXT I WANT INSERTED".to_string()],
+            ..OwnersFileConfig::default()
+        };
+
+        let parsed = OwnersFileConfig::from_text(input, "test data", "test data")?;
+        assert_eq!(parsed, expected);
+        Ok(())
+    }
+
+    #[test]
+    fn parse_with_multiple_inserts() -> anyhow::Result<()> {
+        let input = indoc! {"\
+            ada.lovelace
+            insert first line
+            insert second line
+            "
+        };
+        let expected = OwnersFileConfig {
+            all_files: OwnersSet {
+                inherit: None,
+                owners: vec!["ada.lovelace"]
+                    .into_iter()
+                    .map(|s| s.to_string())
+                    .collect::<HashSet<String>>(),
+            },
+            insertions: vec!["first line".to_string(), "second line".to_string()],
+            ..OwnersFileConfig::default()
+        };
+
+        let parsed = OwnersFileConfig::from_text(input, "test data", "test data")?;
+        assert_eq!(parsed, expected);
+        Ok(())
+    }
+
+    #[test]
+    fn parse_insert_not_allowed_in_pattern_section() {
+        let input = indoc! {"\
+            ada.lovelace
+            [*.rs]
+            insert not allowed here
+            "
+        };
+        let result = OwnersFileConfig::from_text(input, "test data", "test data");
+        assert!(result.is_err());
     }
 }

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -46,12 +46,19 @@ where
     let root = repo_root.unwrap_or(std::env::current_dir()?);
     let tree = OwnersTree::load_from_files(root, allow_filter)?;
 
-    let codeowners = generate_codeowners(&tree, implicit_inherit)?;
+    let (codeowners, insertions) = generate_codeowners(&tree, implicit_inherit)?;
     let mut codeowners_text = to_codeowners_string(codeowners);
     let auto_generated_notice = get_auto_generated_notice(message);
 
-    codeowners_text =
-        format!("{auto_generated_notice}\n\n{codeowners_text}\n\n{auto_generated_notice}");
+    let insertions_text = insertions.join("\n");
+    if insertions_text.is_empty() {
+        codeowners_text =
+            format!("{auto_generated_notice}\n\n{codeowners_text}\n\n{auto_generated_notice}");
+    } else {
+        codeowners_text = format!(
+            "{auto_generated_notice}\n\n{insertions_text}\n\n{codeowners_text}\n\n{auto_generated_notice}"
+        );
+    }
 
     match output_file {
         None => println!("{}", codeowners_text),
@@ -468,5 +475,63 @@ mod test {
             "A much longer custom message which doesn't fit on a single line. It will need to be wrapped into multiple \
             lines, neatly.";
         assert_eq!(get_auto_generated_notice(Some(message)), expected);
+    }
+
+    #[test]
+    fn test_generate_codeowners_from_files_with_insert() -> anyhow::Result<()> {
+        let temp_dir = tempdir()?;
+        let root_dir = temp_dir.path();
+        create_test_file(
+            &temp_dir,
+            "OWNERS",
+            indoc! {
+                "ada.lovelace
+                grace.hopper
+                insert # This is a custom comment
+                insert ^[Special Team] @org/special-team
+                "
+            },
+        )?;
+
+        let expected = indoc! {"\
+            ################################################################################
+            #                             AUTO GENERATED FILE
+            #                            Do Not Manually Update
+            #                              For details, see:
+            #        https://github.com/andrewring/github-distributed-owners#readme
+            ################################################################################
+
+            # This is a custom comment
+            ^[Special Team] @org/special-team
+
+            * @ada.lovelace @grace.hopper
+
+            ################################################################################
+            #                             AUTO GENERATED FILE
+            #                            Do Not Manually Update
+            #                              For details, see:
+            #        https://github.com/andrewring/github-distributed-owners#readme
+            ################################################################################
+            "
+        };
+
+        let output_file = root_dir.join("CODEOWNERS");
+        let repo_root = Some(root_dir.to_path_buf());
+        let implicit_inherit = true;
+        let message = Option::<String>::None;
+
+        generate_codeowners_from_files(
+            repo_root,
+            Some(output_file.clone()),
+            implicit_inherit,
+            &ALLOW_ANY,
+            message,
+        )?;
+
+        let generated_codeowners = fs::read_to_string(output_file)?;
+
+        assert_eq!(generated_codeowners, expected);
+
+        Ok(())
     }
 }


### PR DESCRIPTION
Allow the insertion of special strings, e.g. the creation of sections or addition of comments in the generated CODEOWNERS file