### PR TITLE
Update workflow names and action versions

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -1,4 +1,4 @@
-name: CI
+name: Build & Test
 
 on:
   pull_request:
@@ -10,19 +10,13 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@1.90.0
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release --all-features
+      - run: cargo build --release --all-features
   test:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@1.90.0
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all-features
+      - run: cargo test --all-features

--- a/.github/workflows/cargo-deny.yaml
+++ b/.github/workflows/cargo-deny.yaml
@@ -1,12 +1,12 @@
-name: CI
+name: Cargo Deny
 
 on:
   pull_request:
   push:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
-  build:
+  cargo-deny:
     name: cargo-deny
     runs-on: ubuntu-latest
     strategy:
@@ -19,7 +19,7 @@ jobs:
     continue-on-error: ${{ matrix.checks == 'advisories' }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: EmbarkStudios/cargo-deny-action@v2
         with:
           rust-version: '1.90.0'

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -1,4 +1,4 @@
-name: CI
+name: Pre-commit
 
 on:
   pull_request:
@@ -9,9 +9,9 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v5
       - uses: dtolnay/rust-toolchain@1.90.0
         with:
           components: rustfmt, clippy
-      - uses: pre-commit/action@v3.0.0
+      - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -82,7 +82,7 @@ jobs:
             target: x86_64-pc-windows-msvc
             asset_name: github-distributed-owners-windows-amd64.exe
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ env.TAG }}
 


### PR DESCRIPTION
## Summary

- Rename all three existing workflows from generic "CI" to distinct names: **Build & Test**, **Cargo Deny**, **Pre-commit**
- Bump `actions/checkout` from v3 to v6 across all workflows (v4 to v6 in release.yaml)
- Replace archived `actions-rs/cargo@v1` with direct `cargo` commands
- Bump `actions/setup-python` from v3 to v5
- Bump `pre-commit/action` from v3.0.0 to v3.0.1

#### Test plan

- [x] Verify all three CI workflows pass on this PR
- [x] Confirm workflows show distinct names in the Actions tab - confirmed after merge

Generated with [Devin](https://cli.devin.ai/docs)