### PR TITLE
Add tag to release workflow run name

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,5 @@
 name: Release Binaries
+run-name: Release Binaries (${{ inputs.tag || github.event.release.tag_name }})
 
 on:
   release:


### PR DESCRIPTION
## Summary

Adds `run-name` to the release workflow so each run shows the tag in the Actions list, e.g. "Release Binaries (v0.1.12)".

Tested in [this run](https://github.com/andrewring/github-distributed-owners/actions/runs/27591913881).

Generated with [Devin](https://cli.devin.ai/docs)