### PR TITLE
Add Docker pre-commit hook and version consistency check

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -6,6 +6,70 @@ on:
     branches: [main]
 
 jobs:
+  version-consistency:
+    name: Version Consistency
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Check version consistency
+        run: |
+          errors=0
+          results=""
+
+          # Extract source-of-truth values
+          pkg_version=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
+          rust_version=$(grep '^channel' rust-toolchain.toml | sed 's/.*"\(.*\)".*/\1/')
+          echo "Package version: $pkg_version"
+          echo "Rust version: $rust_version"
+
+          check() {
+            local file="$1" pattern="$2" label="$3"
+            if ! grep -q "$pattern" "$file"; then
+              echo "::error file=$file::$label: expected '$pattern' in $file"
+              results+="| $label | \`$file\` | :x: Missing |"$'\n'
+              errors=$((errors + 1))
+            else
+              echo "OK: $label"
+              results+="| $label | \`$file\` | :white_check_mark: |"$'\n'
+            fi
+          }
+
+          # Package version checks
+          check .pre-commit-hooks.yaml "ghcr.io/andrewring/github-distributed-owners:${pkg_version}" \
+            "Docker hook image tag"
+          check README.md "rev: v${pkg_version}" \
+            "README pre-commit rev"
+          check Cargo.toml "rust-version = \"${rust_version}\"" \
+            "Cargo.toml rust-version"
+
+          # Rust version checks
+          check .github/workflows/build-and-test.yaml "rust-toolchain@${rust_version}" \
+            "build-and-test.yaml toolchain"
+          check .github/workflows/pre-commit.yaml "rust-toolchain@${rust_version}" \
+            "pre-commit.yaml toolchain"
+          check .github/workflows/cargo-deny.yaml "rust-version: '${rust_version}'" \
+            "cargo-deny.yaml rust-version"
+
+          # Write summary
+          {
+            echo "## Version Consistency"
+            echo ""
+            echo "| Source | Value |"
+            echo "| --- | --- |"
+            echo "| **Package version** (Cargo.toml) | \`$pkg_version\` |"
+            echo "| **Rust version** (rust-toolchain.toml) | \`$rust_version\` |"
+            echo ""
+            echo "| Check | File | Status |"
+            echo "| --- | --- | --- |"
+            echo -n "$results"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "$errors" -gt 0 ]; then
+            echo "::error::Found $errors version inconsistencies"
+            exit 1
+          fi
+          echo "All versions consistent"
+
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -195,7 +195,8 @@ jobs:
       - name: Create Dockerfile
         run: |
           cat > Dockerfile <<'DOCKERFILE'
-          FROM scratch
+          FROM alpine:3
+          RUN apk add --no-cache git
           ARG TARGETARCH
           COPY --chmod=755 github-distributed-owners-linux-${TARGETARCH} /github-distributed-owners
           ENTRYPOINT ["/github-distributed-owners"]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -7,3 +7,12 @@
   args: ["--output-file=.github/CODEOWNERS"]
   pass_filenames: false
   require_serial: true
+- id: github-distributed-owners-docker
+  name: GitHub Distributed Owners (Docker)
+  description: Auto generate a GitHub compatible CODEOWNERS files from OWNERS files distributed through the file tree. Uses a pre-built Docker image instead of compiling from source.
+  entry: ghcr.io/andrewring/github-distributed-owners:0.1.12
+  language: docker_image
+  types: [file, text]
+  args: ["--output-file=.github/CODEOWNERS"]
+  pass_filenames: false
+  require_serial: true

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,10 @@
+# Selecting either hook will generate the same CODEOWNERS file from the
+# OWNERS files distributed through the file tree. The docker-based hook
+# requires docker to be installed, while the rust-based hook requires
+# the rust compiler to be installed.
 - id: github-distributed-owners
   name: GitHub Distributed Owners
-  description: Auto generate a GitHub compatible CODEOWNERS files from OWNERS files distributed through the file tree.
+  description: Auto generate a GitHub compatible CODEOWNERS files from OWNERS files distributed through the file tree. Builds from source, requiring the rust compiler.
   entry: github-distributed-owners
   language: rust
   types: [file, text]

--- a/README.md
+++ b/README.md
@@ -53,6 +53,18 @@ repos:
     hooks:
       - id: github-distributed-owners
 ```
+
+A Docker-based hook is also available, which uses a pre-built image and does not require a Rust
+toolchain:
+
+```yaml
+repos:
+  - repo: https://github.com/andrewring/github-distributed-owners
+    rev: v0.1.12
+    hooks:
+      - id: github-distributed-owners-docker
+```
+
 > [!WARNING]
 > pre-commit does not trigger on deletion of files matching patterns,
 > so removal of an OWNERS file can be missed by pre-commit.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ github-distributed-owners --output-file .github/CODEOWNERS
 
 ### Pre-commit
 
+Selecting either hook will generate the same CODEOWNERS file from the OWNERS
+files distributed through the file tree. The docker-based hook requires docker
+to be installed, while the rust-based hook requires the rust compiler to be
+installed.
+
 Example pre-commit config:
 
 ```yaml


### PR DESCRIPTION
## Summary

- Adds a `github-distributed-owners-docker` pre-commit hook using `language: docker_image`, which pulls the pre-built GHCR image instead of compiling from source. No Rust toolchain required — just Docker.
- The existing `language: rust` hook is unchanged.
- Updates README with Docker hook usage example.
- Adds a version consistency check to the Build & Test workflow that verifies hardcoded versions stay in sync:
  - Package version (`Cargo.toml`) matches `.pre-commit-hooks.yaml` docker image tag and `README.md` rev examples
  - Rust version (`rust-toolchain.toml`) matches `Cargo.toml` rust-version and all workflow toolchain references

#### Test plan

- [x] Verify version consistency check passes in CI
- [x] Test Docker pre-commit hook locally: `pre-commit try-repo . github-distributed-owners-docker --all-files`

Generated with [Devin](https://cli.devin.ai/docs)